### PR TITLE
fix: improve error messaging for missing dependencies

### DIFF
--- a/train_pipeline.py
+++ b/train_pipeline.py
@@ -219,7 +219,12 @@ def check_environment():
         logger.error("Missing required packages:")
         for package in missing_packages:
             logger.error(f"  - {package}")
-        logger.error("\nInstall missing packages with:")
+        logger.error("")
+        logger.error("🔧 SOLUTION:")
+        logger.error("Install all dependencies from requirements.txt:")
+        logger.error("pip install -r requirements.txt")
+        logger.error("")
+        logger.error("Or install missing packages individually:")
         logger.error("pip install " + " ".join(missing_packages))
         return False
     


### PR DESCRIPTION
This PR improves the error handling in train_pipeline.py to provide clearer instructions when dependencies are missing.

## Changes:
- Enhanced `check_environment()` function with structured error messages
- Added prominent "pip install -r requirements.txt" recommendation
- Improved user experience with clear solution guidance

## Problem Solved:
Users were getting confusing error messages about missing scikit-learn, even though it's properly listed in requirements.txt. The issue was that users needed to install dependencies first, but the error message wasn't clear about this.

Fixes #4

Generated with [Claude Code](https://claude.ai/code)