### PR TITLE
fix: correct scikit-learn module name in dependency check

### DIFF
--- a/train_pipeline.py
+++ b/train_pipeline.py
@@ -202,7 +202,7 @@ def run_complete_pipeline(use_sample_data: bool = True):
 def check_environment():
     """Check if all required packages are available"""
     required_packages = [
-        'pandas', 'numpy', 'scikit-learn', 'lightgbm', 'xgboost', 
+        'pandas', 'numpy', 'sklearn', 'lightgbm', 'xgboost', 
         'catboost', 'optuna', 'matplotlib', 'seaborn', 'plotly',
         'streamlit', 'joblib', 'scipy', 'yaml'
     ]


### PR DESCRIPTION
This PR fixes the persistent scikit-learn dependency error in train_pipeline.py.

## Problem:
The `check_environment()` function was trying to import 'scikit-learn' but the actual Python module name is 'sklearn'. This caused the dependency check to fail even when scikit-learn was properly installed via `pip install scikit-learn`.

## Solution:
- Changed 'scikit-learn' to 'sklearn' in the required_packages list (line 205)
- Now the import check correctly detects scikit-learn installation

## Testing:
The script should now run without dependency errors when requirements.txt dependencies are installed.

Fixes #4

Generated with [Claude Code](https://claude.ai/code)