### PR TITLE
fix: correct ModelTrainer initialization parameters

### DIFF
--- a/train_pipeline.py
+++ b/train_pipeline.py
@@ -209,15 +209,8 @@ def run_complete_pipeline(use_sample_data: bool = True):
     logger.info("="*40)
     
     try:
-        # Initialize trainer with configuration
-        models_config = config.get('models', {})
-        optimization_config = config.get('optimization', {})
-        
-        trainer = ModelTrainer(
-            random_state=models_config.get('random_state', 42),
-            cv_folds=models_config.get('cv_folds', 5),
-            n_trials=optimization_config.get('n_trials', 100)
-        )
+        # Initialize trainer (it will load configuration from config.yaml internally)
+        trainer = ModelTrainer()
         
         # Train base models
         logger.info("Training base models...")


### PR DESCRIPTION
This PR fixes the train_pipeline.py error where ModelTrainer was receiving unexpected keyword arguments.

## Problem:
ModelTrainer.__init__ only accepts `config_path` parameter, but train_pipeline.py was passing `random_state`, `cv_folds`, and `n_trials` parameters directly, causing:
```
ModelTrainer.__init__() got an unexpected keyword argument 'random_state'
```

## Solution:
- Removed incorrect parameters from ModelTrainer initialization
- ModelTrainer now loads configuration from config.yaml internally as designed
- Falls back to default values if config.yaml is not available

## Testing:
The training pipeline should now run without parameter errors.

Fixes #4

Generated with [Claude Code](https://claude.ai/code)